### PR TITLE
Adição de script de despesas de gabinetes

### DIFF
--- a/scraper_alesp_gastos_gabinetes.py
+++ b/scraper_alesp_gastos_gabinetes.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+"""
+Crawler de despesas de gabinetes da Assembleia Legislativa do Estado de São Paulo
+Criado em 8 de janeiro de 2018, às 00:49:56
+@author: rodolfoviana
+"""
+
+import xml.etree.cElementTree as ET
+import csv
+
+tree = ET.parse('despesas_gabinetes.xml')
+root = tree.getroot()
+
+with open('resultado.csv', 'w', encoding='utf-8') as despesas:
+    csvwriter = csv.writer(despesas, delimiter=';')
+    cabecalhos = []
+    count = 0
+    for i in root.findall('despesa'):
+	    dep = []
+	    if count == 0:
+		    deputado = i.find('Deputado').tag
+		    cabecalhos.append(deputado)
+		    matricula = i.find('Matricula').tag
+		    cabecalhos.append(matricula)
+		    ano = i.find('Ano').tag
+		    cabecalhos.append(ano)
+		    mes = i.find('Mes').tag
+		    cabecalhos.append(mes)
+		    tipo = i.find('Tipo').tag
+		    cabecalhos.append(tipo)
+		    cnpj = i.find('CNPJ').tag
+		    cabecalhos.append(cnpj)
+		    fornecedor = i.find('Fornecedor').tag
+		    cabecalhos.append(fornecedor)
+		    valor = i.find('Valor').tag
+		    cabecalhos.append(valor)
+		    csvwriter.writerow(cabecalhos)
+		    count += 1
+
+	    deputado = i.find('Deputado').text
+	    dep.append(deputado)
+	    matricula = i.find('Matricula').text
+	    dep.append(matricula)
+	    ano = i.find('Ano').text
+	    dep.append(ano)
+	    mes = i.find('Mes').text
+	    dep.append(mes)
+	    tipo = i.find('Tipo').text
+	    dep.append(tipo)
+	    cnpj = i.find('CNPJ').text if i.find('CNPJ') else None
+	    dep.append(cnpj)
+	    fornecedor = i.find('Fornecedor').text
+	    dep.append(fornecedor)
+	    valor = i.find('Valor').text
+	    dep.append(valor)
+	    csvwriter.writerow(dep)
+despesas.close()

--- a/scraper_alesp_gastos_gabinetes.py
+++ b/scraper_alesp_gastos_gabinetes.py
@@ -5,53 +5,82 @@ Criado em 8 de janeiro de 2018, às 00:49:56
 @author: rodolfoviana
 """
 
+from __future__ import print_function
+from xml.sax import ContentHandler, parse
+import requests
 import xml.etree.cElementTree as ET
 import csv
 
-tree = ET.parse('despesas_gabinetes.xml')
-root = tree.getroot()
+file = requests.get('http://www.al.sp.gov.br/repositorioDados/deputados/despesas_gabinetes.xml')
 
-with open('resultado.csv', 'w', encoding='utf-8') as despesas:
-    csvwriter = csv.writer(despesas, delimiter=';')
-    cabecalhos = []
-    count = 0
-    for i in root.findall('despesa'):
-	    dep = []
-	    if count == 0:
-		    deputado = i.find('Deputado').tag
-		    cabecalhos.append(deputado)
-		    matricula = i.find('Matricula').tag
-		    cabecalhos.append(matricula)
-		    ano = i.find('Ano').tag
-		    cabecalhos.append(ano)
-		    mes = i.find('Mes').tag
-		    cabecalhos.append(mes)
-		    tipo = i.find('Tipo').tag
-		    cabecalhos.append(tipo)
-		    cnpj = i.find('CNPJ').tag
-		    cabecalhos.append(cnpj)
-		    fornecedor = i.find('Fornecedor').tag
-		    cabecalhos.append(fornecedor)
-		    valor = i.find('Valor').tag
-		    cabecalhos.append(valor)
-		    csvwriter.writerow(cabecalhos)
-		    count += 1
+with open('despesas_gabinetes.xml','wb') as f:
+	f.write(file.content)
 
-	    deputado = i.find('Deputado').text
-	    dep.append(deputado)
-	    matricula = i.find('Matricula').text
-	    dep.append(matricula)
-	    ano = i.find('Ano').text
-	    dep.append(ano)
-	    mes = i.find('Mes').text
-	    dep.append(mes)
-	    tipo = i.find('Tipo').text
-	    dep.append(tipo)
-	    cnpj = i.find('CNPJ').text if i.find('CNPJ') else None
-	    dep.append(cnpj)
-	    fornecedor = i.find('Fornecedor').text
-	    dep.append(fornecedor)
-	    valor = i.find('Valor').text
-	    dep.append(valor)
-	    csvwriter.writerow(dep)
-despesas.close()
+class Handler(ContentHandler):
+
+    def __init__(self):
+        ContentHandler.__init__(self)
+        self.despesa = {}
+        self.despesas = []
+        self.current_field = None
+        self.in_despesa = False
+        self.indent = 0
+
+    def startElement(self, name, attrs):
+        print('{}Start element: {}'.format('\t' * self.indent, name))
+        self.indent += 1
+        if self.in_despesa:
+            self.current_field = name
+            self.despesa[name] = ''
+
+        if name == 'despesa':
+            self.in_despesa = True
+
+    def endElement(self, name):
+        self.indent -= 1
+        print('{}End element: {}'.format('\t' * self.indent, name))
+        if name == 'despesa':
+            self.despesas.append(self.despesa)
+            self.despesa = {}
+            self.in_despesa = False
+            self.current_field = None
+
+    def characters(self, content):
+        if content.strip():
+            print('{}chars: {}'.format('\t' * self.indent, repr(content)))
+        if self.in_despesa and self.current_field:
+            self.despesa[self.current_field] += content
+
+
+def gravar_despesas(writer, despesas):
+    cabecalhos = [
+        'Deputado',
+        'Matricula',
+        'Ano',
+        'Mes',
+        'Tipo',
+        'CNPJ',
+        'Fornecedor',
+        'Valor'
+    ]
+    writer.writerow(cabecalhos)
+
+    for despesa in despesas:
+        writer.writerow([despesa.get(c, '').strip() for c in cabecalhos])
+
+
+def main():
+
+    handler = Handler()
+    with open('despesas_gabinetes.xml', 'r', encoding='utf-8') as xml_file:
+        parse(xml_file, handler)
+
+    print('Found {} despesas'.format(len(handler.despesas)))
+
+    with open('despesas.csv', 'w', encoding='latin-1') as f_handle:
+        writer = csv.writer(f_handle)
+        gravar_despesas(writer, handler.despesas)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Esta versão ainda requer que o arquivo `.xml` seja previamente baixado no computador para ser convertido em `.csv` (que é o formato usado para leitura de Pandas). Em breve vou alterá-lo para que baixe diretamente do [site da Alesp](https://www.al.sp.gov.br/dados-abertos/recurso/21), sem precisar salvar.

Ah, alguém sabe dizer o que fiz de errado para que os CNPJs não venham? Ele tem um `if` porque há valores nulos, o que quebra o código. Contudo, o `if` faz com que nenhum CNPJ seja apensado. Se alguém souber a solução, serei grato. :)